### PR TITLE
fix: add documentation to satisfy linting

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -41,12 +41,12 @@
 ### Resource types
 
 * [`zabbix_application`](#zabbix_application): Manage zabbix applications  Example:   zabbix_application{"app1":     ensure   => present,     template => 'template1',   } It Raise exceptio
-* [`zabbix_host`](#zabbix_host): FQDN of the machine.
+* [`zabbix_host`](#zabbix_host): Manage zabbix hosts
 * [`zabbix_hostgroup`](#zabbix_hostgroup): Manage zabbix hostgroups
-* [`zabbix_proxy`](#zabbix_proxy): FQDN of the proxy.
-* [`zabbix_template`](#zabbix_template): The name of template.
+* [`zabbix_proxy`](#zabbix_proxy): Manage zabbix proxies
+* [`zabbix_template`](#zabbix_template): Manage zabbix templates
 * [`zabbix_template_host`](#zabbix_template_host): Link or Unlink template to host. Only for Zabbix < 6.0!  Example:   zabbix_template_host{ 'mysql_template@db1':     ensure => present,   } Na
-* [`zabbix_userparameters`](#zabbix_userparameters): An unique name for this define.
+* [`zabbix_userparameters`](#zabbix_userparameters): Manage zabbix user templates
 
 ### Data types
 
@@ -5973,7 +5973,7 @@ template to which the application is linked
 
 ### <a name="zabbix_host"></a>`zabbix_host`
 
-FQDN of the machine.
+Manage zabbix hosts
 
 #### Properties
 
@@ -6112,7 +6112,7 @@ usually discover the appropriate provider for your platform.
 
 ### <a name="zabbix_proxy"></a>`zabbix_proxy`
 
-FQDN of the proxy.
+Manage zabbix proxies
 
 #### Properties
 
@@ -6170,7 +6170,7 @@ usually discover the appropriate provider for your platform.
 
 ### <a name="zabbix_template"></a>`zabbix_template`
 
-The name of template.
+Manage zabbix templates
 
 #### Properties
 
@@ -6289,7 +6289,7 @@ will usually discover the appropriate provider for your platform.
 
 ### <a name="zabbix_userparameters"></a>`zabbix_userparameters`
 
-An unique name for this define.
+Manage zabbix user templates
 
 #### Properties
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -40,12 +40,12 @@
 
 ### Resource types
 
-* [`zabbix_application`](#zabbix_application): %q(Manage zabbix applications      zabbix_application{"app1":       ensure   => present,       template => 'template1',     }  It Raise excep
+* [`zabbix_application`](#zabbix_application): Manage zabbix applications  Example:   zabbix_application{"app1":     ensure   => present,     template => 'template1',   } It Raise exceptio
 * [`zabbix_host`](#zabbix_host): FQDN of the machine.
 * [`zabbix_hostgroup`](#zabbix_hostgroup): Manage zabbix hostgroups
 * [`zabbix_proxy`](#zabbix_proxy): FQDN of the proxy.
 * [`zabbix_template`](#zabbix_template): The name of template.
-* [`zabbix_template_host`](#zabbix_template_host): Link or Unlink template to host. Only for Zabbix < 6.0! Example. Name should be in the format of "template_name@hostname"  zabbix_template_ho
+* [`zabbix_template_host`](#zabbix_template_host): Link or Unlink template to host. Only for Zabbix < 6.0!  Example:   zabbix_template_host{ 'mysql_template@db1':     ensure => present,   } Na
 * [`zabbix_userparameters`](#zabbix_userparameters): An unique name for this define.
 
 ### Data types
@@ -5927,16 +5927,14 @@ Default value: `'0644'`
 
 ### <a name="zabbix_application"></a>`zabbix_application`
 
-%q(Manage zabbix applications
+Manage zabbix applications
 
-    zabbix_application{"app1":
-      ensure   => present,
-      template => 'template1',
-    }
-
+Example:
+  zabbix_application{"app1":
+    ensure   => present,
+    template => 'template1',
+  }
 It Raise exception on deleting an application which is a part of used template.
-
-)
 
 #### Properties
 
@@ -6250,12 +6248,12 @@ Zabbix version that the template will be installed on.
 ### <a name="zabbix_template_host"></a>`zabbix_template_host`
 
 Link or Unlink template to host. Only for Zabbix < 6.0!
-Example.
-Name should be in the format of "template_name@hostname"
 
-zabbix_template_host{ 'mysql_template@db1':
-      ensure => present,
-    }
+Example:
+  zabbix_template_host{ 'mysql_template@db1':
+    ensure => present,
+  }
+Name should be in the format of "template_name@hostname"
 
 #### Properties
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -51,7 +51,7 @@
 ### Data types
 
 * [`Zabbix::Databases`](#Zabbix--Databases): Type for supported databases by the zabbix module
-* [`Zabbix::Historyics`](#Zabbix--Historyics)
+* [`Zabbix::Historyics`](#Zabbix--Historyics): Type for size values in bytes (also allows k/K and m/M as appendix)
 
 ## Classes
 
@@ -6343,7 +6343,7 @@ Alias of `Enum['postgresql', 'mysql', 'sqlite']`
 
 ### <a name="Zabbix--Historyics"></a>`Zabbix::Historyics`
 
-The Zabbix::Historyics data type.
+Type for size values in bytes (also allows k/K and m/M as appendix)
 
 Alias of `Optional[Pattern[/^\d+[k|K|m|M]?$/]]`
 

--- a/lib/puppet/provider/zabbix_application/ruby.rb
+++ b/lib/puppet/provider/zabbix_application/ruby.rb
@@ -2,6 +2,7 @@
 
 require_relative '../zabbix'
 Puppet::Type.type(:zabbix_application).provide(:ruby, parent: Puppet::Provider::Zabbix) do
+  desc 'Puppet provider for Zabbix application using the Zabbix API.2'
   confine feature: :zabbixapi
 
   def template_id

--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -2,6 +2,7 @@
 
 require_relative '../zabbix'
 Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix) do
+  desc 'Puppet provider for managing Zabbix hosts. It uses the Zabbix API to create, read, update and delete hosts.'
   confine feature: :zabbixapi
 
   def self.instances

--- a/lib/puppet/provider/zabbix_hostgroup/ruby.rb
+++ b/lib/puppet/provider/zabbix_hostgroup/ruby.rb
@@ -2,6 +2,7 @@
 
 require_relative '../zabbix'
 Puppet::Type.type(:zabbix_hostgroup).provide(:ruby, parent: Puppet::Provider::Zabbix) do
+  desc 'Puppet provider for managing Zabbix hostgroups. It defines methods to create, check if exists, and destroy Zabbix hostgroups using the Zabbix API.'
   confine feature: :zabbixapi
 
   def self.instances

--- a/lib/puppet/provider/zabbix_proxy/ruby.rb
+++ b/lib/puppet/provider/zabbix_proxy/ruby.rb
@@ -2,6 +2,7 @@
 
 require_relative '../zabbix'
 Puppet::Type.type(:zabbix_proxy).provide(:ruby, parent: Puppet::Provider::Zabbix) do
+  desc 'Puppet provider for managing Zabbix proxies. It uses the Zabbix API to create, read, update and delete hosts, as well as changing them between active and passive modes.'
   confine feature: :zabbixapi
 
   def initialize(value = {})

--- a/lib/puppet/provider/zabbix_template/ruby.rb
+++ b/lib/puppet/provider/zabbix_template/ruby.rb
@@ -2,6 +2,7 @@
 
 require_relative '../zabbix'
 Puppet::Type.type(:zabbix_template).provide(:ruby, parent: Puppet::Provider::Zabbix) do
+  desc 'Puppet provider that manages Zabbix templates by importing and exporting them in XML format, and creating, updating, or deleting various Zabbix configuration objects. It includes conditional logic based on the Zabbix version being used.'
   confine feature: :zabbixapi
 
   def create

--- a/lib/puppet/provider/zabbix_template_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_template_host/ruby.rb
@@ -2,6 +2,7 @@
 
 require_relative '../zabbix'
 Puppet::Type.type(:zabbix_template_host).provide(:ruby, parent: Puppet::Provider::Zabbix) do
+  desc 'Puppet provider that manages the association between Zabbix templates and hosts. It allows creating, checking the existence of, and deleting the association between a Zabbix template and a host, using the Zabbix API.'
   confine feature: :zabbixapi
   def template_name
     @template_name ||= @resource[:name].split('@')[0]

--- a/lib/puppet/provider/zabbix_userparameters/ruby.rb
+++ b/lib/puppet/provider/zabbix_userparameters/ruby.rb
@@ -2,6 +2,7 @@
 
 require_relative '../zabbix'
 Puppet::Type.type(:zabbix_userparameters).provide(:ruby, parent: Puppet::Provider::Zabbix) do
+  desc 'Puppet provider that manages Zabbix user parameters. It allows users to define custom monitoring parameters in Zabbix, and provides methods for creating and checking the existence of a user parameter. It also has a placeholder method for destroying the user parameter.'
   confine feature: :zabbixapi
 
   def create

--- a/lib/puppet/type/zabbix_application.rb
+++ b/lib/puppet/type/zabbix_application.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 Puppet::Type.newtype(:zabbix_application) do
-  @doc = %q(Manage zabbix applications
+  @doc = <<-DOC
+    Manage zabbix applications
 
+    Example:
       zabbix_application{"app1":
         ensure   => present,
         template => 'template1',
       }
-
-  It Raise exception on deleting an application which is a part of used template.
-
-  )
+    It Raise exception on deleting an application which is a part of used template.
+  DOC
 
   ensurable do
     defaultvalues

--- a/lib/puppet/type/zabbix_application.rb
+++ b/lib/puppet/type/zabbix_application.rb
@@ -13,6 +13,7 @@ Puppet::Type.newtype(:zabbix_application) do
   DOC
 
   ensurable do
+    desc 'The basic property that the resource should be in.'
     defaultvalues
     defaultto :present
   end

--- a/lib/puppet/type/zabbix_host.rb
+++ b/lib/puppet/type/zabbix_host.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 Puppet::Type.newtype(:zabbix_host) do
+  @doc = 'Manage zabbix hosts'
+
   ensurable do
+    desc 'The basic property that the resource should be in.'
     defaultvalues
     defaultto :present
   end

--- a/lib/puppet/type/zabbix_hostgroup.rb
+++ b/lib/puppet/type/zabbix_hostgroup.rb
@@ -4,6 +4,7 @@ Puppet::Type.newtype(:zabbix_hostgroup) do
   @doc = 'Manage zabbix hostgroups'
 
   ensurable do
+    desc 'The basic property that the resource should be in.'
     defaultvalues
     defaultto :present
   end

--- a/lib/puppet/type/zabbix_proxy.rb
+++ b/lib/puppet/type/zabbix_proxy.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 Puppet::Type.newtype(:zabbix_proxy) do
+  @doc = 'Manage zabbix proxies'
+
   ensurable do
+    desc 'The basic property that the resource should be in.'
     defaultvalues
     defaultto :present
   end

--- a/lib/puppet/type/zabbix_template.rb
+++ b/lib/puppet/type/zabbix_template.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 Puppet::Type.newtype(:zabbix_template) do
+  @doc = 'Manage zabbix templates'
+
   ensurable do
+    desc 'The basic property that the resource should be in.'
     defaultvalues
     defaultto :present
 

--- a/lib/puppet/type/zabbix_template_host.rb
+++ b/lib/puppet/type/zabbix_template_host.rb
@@ -12,6 +12,7 @@ Puppet::Type.newtype(:zabbix_template_host) do
   DOC
 
   ensurable do
+    desc 'The basic property that the resource should be in.'
     defaultvalues
     defaultto :present
   end

--- a/lib/puppet/type/zabbix_template_host.rb
+++ b/lib/puppet/type/zabbix_template_host.rb
@@ -3,12 +3,12 @@
 Puppet::Type.newtype(:zabbix_template_host) do
   @doc = <<-DOC
     Link or Unlink template to host. Only for Zabbix < 6.0!
-	  Example.
-	  Name should be in the format of "template_name@hostname"
 
-	  zabbix_template_host{ 'mysql_template@db1':
-      ensure => present,
-    }
+    Example:
+      zabbix_template_host{ 'mysql_template@db1':
+        ensure => present,
+      }
+    Name should be in the format of "template_name@hostname"
   DOC
 
   ensurable do

--- a/lib/puppet/type/zabbix_userparameters.rb
+++ b/lib/puppet/type/zabbix_userparameters.rb
@@ -2,7 +2,10 @@
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..'))
 Puppet::Type.newtype(:zabbix_userparameters) do
+  @doc = 'Manage zabbix user templates'
+
   ensurable do
+    desc 'The basic property that the resource should be in.'
     defaultvalues
     defaultto :present
   end

--- a/types/historyics.pp
+++ b/types/historyics.pp
@@ -1,1 +1,2 @@
+# @summary Type for size values in bytes (also allows k/K and m/M as appendix)
 type Zabbix::Historyics = Optional[Pattern[/^\d+[k|K|m|M]?$/]]


### PR DESCRIPTION
#### Pull Request (PR) description

fix: add documentation to satisfy linting

fixes these warnings that did pop up when linting:
```
[warn]: Missing documentation for Puppet type alias 'Zabbix::Historyics' at types/historyics.pp:1.
[warn]: Missing a description for Puppet resource property 'ensure' at lib/puppet/type/zabbix_host.rb:4.
[warn]: Missing a description for Puppet resource property 'ensure' at lib/puppet/type/zabbix_proxy.rb:4.
[warn]: Missing a description for Puppet resource property 'ensure' at lib/puppet/type/zabbix_template.rb:4.
[warn]: Missing a description for Puppet resource property 'ensure' at lib/puppet/type/zabbix_hostgroup.rb:6.
[warn]: Missing a description for Puppet resource property 'ensure' at lib/puppet/type/zabbix_application.rb:15.
[warn]: Missing a description for Puppet provider 'ruby' (resource type 'zabbix_host') at lib/puppet/provider/zabbix_host/ruby.rb:4.
[warn]: Missing a description for Puppet resource property 'ensure' at lib/puppet/type/zabbix_template_host.rb:14.
[warn]: Missing a description for Puppet provider 'ruby' (resource type 'zabbix_proxy') at lib/puppet/provider/zabbix_proxy/ruby.rb:4.
[warn]: Missing a description for Puppet resource property 'ensure' at lib/puppet/type/zabbix_userparameters.rb:5.
[warn]: Missing a description for Puppet provider 'ruby' (resource type 'zabbix_template') at lib/puppet/provider/zabbix_template/ruby.rb:4.
[warn]: Missing a description for Puppet provider 'ruby' (resource type 'zabbix_hostgroup') at lib/puppet/provider/zabbix_hostgroup/ruby.rb:4.
[warn]: Missing a description for Puppet provider 'ruby' (resource type 'zabbix_application') at lib/puppet/provider/zabbix_application/ruby.rb:4.
[warn]: Missing a description for Puppet provider 'ruby' (resource type 'zabbix_template_host') at lib/puppet/provider/zabbix_template_host/ruby.rb:4.
[warn]: Missing a description for Puppet provider 'ruby' (resource type 'zabbix_userparameters') at lib/puppet/provider/zabbix_userparameters/ruby.rb:4.
```


